### PR TITLE
Added .p-fileupload-highlight class missing

### DIFF
--- a/theme-base/components/file/_fileupload.scss
+++ b/theme-base/components/file/_fileupload.scss
@@ -23,6 +23,13 @@
         color: $panelContentTextColor;
         border-bottom-right-radius: $borderRadius;
         border-bottom-left-radius: $borderRadius;
+
+        &.p-fileupload-highlight {
+            border-color: $primaryColor;
+            border-width: 2px;
+            border-style: dashed;
+            background-color: $highlightBg;
+        }
     }
 
     .p-fileupload-file {


### PR DESCRIPTION
This fix will **work perfectly** with: https://github.com/primefaces/primevue/pull/4130 (both are necessary)

I have follow the same idea like:
PrimeNG: https://github.com/primefaces/primeng-sass-theme/pull/24
PrimeReact:  https://github.com/primefaces/primereact-sass-theme/pull/28

## PROBLEM

when I'm trying to drag over my file in the component (nothing was happening)

![problem fileupload primevue](https://github.com/primefaces/primevue/assets/19764334/e2533f02-0574-48c8-872d-24b652f6d71e)

## SOLUTION

![fixed fileupload primevue](https://github.com/primefaces/primevue/assets/19764334/9d523e92-f7a3-4b5b-8dec-f1c626099a1b)