### PR TITLE
fix: #63, Password: Hand/Pointer icon not displayed while hovering over the eye icon in password ToggleMask mode

### DIFF
--- a/theme-base/components/input/_password.scss
+++ b/theme-base/components/input/_password.scss
@@ -60,3 +60,7 @@
         }
     }
 }
+
+.p-input-icon-right svg {
+    cursor: pointer;
+}


### PR DESCRIPTION
fix: #63, Password: Hand/Pointer icon not displayed while hovering over the eye icon in password ToggleMask mode