### PR TITLE
fix: IconField compatibility with InputNumber

### DIFF
--- a/theme-base/components/input/_inputicon.scss
+++ b/theme-base/components/input/_inputicon.scss
@@ -4,12 +4,12 @@
     width: 100%;
 }
 
-.p-icon-field-left > .p-input-icon:first-of-type {
+.p-icon-field-left > .p-input-icon {
     left: nth($inputPadding, 2);
     color: $inputIconColor;
 }
 
-.p-icon-field-right > .p-input-icon:last-of-type  {
+.p-icon-field-right > .p-input-icon  {
     right: nth($inputPadding, 2);
     color: $inputIconColor;
 }

--- a/theme-base/components/input/_inputtext.scss
+++ b/theme-base/components/input/_inputtext.scss
@@ -62,7 +62,7 @@
     color: $inputErrorBorderColor;
 }
 
-.p-icon-field-left > .p-inputtext {
+.p-icon-field-left .p-inputtext {
     padding-left: nth($inputPadding, 2) * 2 + $primeIconFontSize;
 }
 
@@ -70,7 +70,7 @@
     left: nth($inputPadding, 2) * 2 + $primeIconFontSize;
 }
 
-.p-icon-field-right > .p-inputtext {
+.p-icon-field-right .p-inputtext {
     padding-right: nth($inputPadding, 2) * 2 + $primeIconFontSize;
 }
 


### PR DESCRIPTION
See initial PR and relevant info [here](https://github.com/primefaces/primevue/pull/6523).

Since V3 of PrimeVue does not seem to have in mind the ability of adding multiple icons in an IconField as V4, the less strict selectors should provide expected results. I am unsure if it could cause potentially problematic results for less standard setups / overrides however and can adapt specificity if needed.